### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release_gem.yaml
+++ b/.github/workflows/release_gem.yaml
@@ -1,0 +1,12 @@
+name: Release
+
+on:
+  create:
+    ref_type: tag
+
+jobs:
+  release:
+    name: Release gem
+    uses: theforeman/actions/.github/workflows/release-gem.yml@v0
+    secrets:
+      api_key: ${{ secrets.RUBYGEM_API_KEY }}


### PR DESCRIPTION
using foreman actions template

Someone with the appropiate permissions needs to set the `secrets.RUBYGEM_API_KEY` api key for this to work https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository
