### PR TITLE
Fix ensure only run js-test on foreman_acd webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lint-fix": "eslint --fix *.js webpack",
     "stylelint": "stylelint webpack/**/*.scss",
     "stylelint-fix": "stylelint webpack/**/*.scss --fix",
-    "test": "jest --no-cache"
+    "test": "jest --no-cache webpack"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
If we only run `jest` it will also run js-tests on all js files it can find, which is a problem if there are folders with other projects in the same folder (e.g. ruby-bundle).
This issue only appears in very specific setups.